### PR TITLE
Fix. Assign headers field in contructor

### DIFF
--- a/src/Provider/HttpProvider.php
+++ b/src/Provider/HttpProvider.php
@@ -74,6 +74,7 @@ class HttpProvider implements HttpProviderInterface
         $this->host = $host;
         $this->timeout = $timeout;
         $this->statusPage = $statusPage;
+        $this->headers = $headers;
 
         $this->httpClient = new Client([
             'base_uri'  =>  $host,


### PR DESCRIPTION
Headers in constructor were not assigned to object field and as a result there were problems in working with transactions