### PR TITLE
Trigger contract functionality

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,7 @@
     "require": {
         "php": "^7.1",
         "guzzlehttp/guzzle": "^6.3",
+        "sc0vu/web3.php": "^0.1.4",
         "simplito/elliptic-php": "^1.0"
     },
 


### PR DESCRIPTION
Calls triggerContract api and returns unsigned transaction with a result
Usage:
```
    $tron = new Tron($fullNode, $solidityNode, $eventServer, $privateKey);
    $transaction = $tron->triggerContract($abi,$contract_address,"contractMethod",$parameters,10000000, $address);
    $signedTransaction = $tron->signTransaction($transaction);
    $result = $tron->sendRawTransaction($signedTransaction);

```
P.S. Uses sc0vu/web3.php Because it has ethereum abi parameters encoding\decoding methods
P.P.S Needs complex tests on different contracts