### PR TITLE
getEventResult should use GET method

### DIFF
--- a/src/Tron.php
+++ b/src/Tron.php
@@ -268,7 +268,7 @@ class Tron implements TronInterface
         }
 
         $routeParams = implode('/', $routeParams);
-        return $this->manager->request("event/contract/{$routeParams}?since={$sinceTimestamp}");
+        return $this->manager->request("event/contract/{$routeParams}?since={$sinceTimestamp}",[],"get");
     }
 
 


### PR DESCRIPTION
when I invoked getEventResult i've got an error "Method not allowed" Because default behavior of request manager uses POST instead of GET 