### PR TITLE
Fix anonymous methods trigger

### DIFF
--- a/src/TransactionBuilder.php
+++ b/src/TransactionBuilder.php
@@ -417,7 +417,7 @@ class TransactionBuilder
     {
         $func_abi = [];
         foreach($abi as $key =>$item) {
-            if($item['name'] === $function) {
+            if(isset($item['name']) && $item['name'] === $function) {
                 $func_abi = $item;
                 break;
             }


### PR DESCRIPTION
Very often there are anonymous functions in contract (the functions without name attribute in abi) e.g. constructor, fallback etc.

This fix was introduced in one of the previous pull requests but was reverted by you.
You should really take a closer look at this function.
Yes I know this may disable call of fallback functions or a constrcutor but i think there should be a separate methods for theese functions.