### PR TITLE
Add new trigger constant contract method

### DIFF
--- a/src/TransactionBuilder.php
+++ b/src/TransactionBuilder.php
@@ -491,10 +491,10 @@ class TransactionBuilder
      * @throws TronException
      */
     public function triggerConstantContract($abi,
-                                         $contract,
-                                         $function,
-                                         $params = [],
-                                         $address = '410000000000000000000000000000000000000000')
+                                            $contract,
+                                            $function,
+                                            $params = [],
+                                            $address = '410000000000000000000000000000000000000000')
     {
         $func_abi = [];
         foreach($abi as $key =>$item) {

--- a/src/Tron.php
+++ b/src/Tron.php
@@ -1201,7 +1201,7 @@ class Tron implements TronInterface
         $address = Base58Check::decode($address, 0, 0, false);
         $utf8 = hex2bin($address);
 
-        if (strlen($utf8) !== 25 or strpos($utf8, self::ADDRESS_PREFIX_BYTE) !== 0)
+        if (strlen($utf8) !== 25 or strpos($utf8, chr(self::ADDRESS_PREFIX_BYTE)) !== 0)
             return false;
 
         $checkSum = substr($utf8, 21);


### PR DESCRIPTION
This PR just adds a new trigger constant contract method to allow users call `view` functions of contracts.
Like `decimals`, `totalSupply`, etc.