### PR TITLE
Update TronAwareTrait.php

### DIFF
--- a/src/TronAwareTrait.php
+++ b/src/TronAwareTrait.php
@@ -114,10 +114,10 @@ trait TronAwareTrait
      * Convert float to trx format
      *
      * @param $double
-     * @return int
+     * @return double
      */
-    public function toTron($double): int {
-        return (int) bcmul((string)$double, (string)1e6,0);
+    public function toTron($double) {
+        return $double;
     }
 
     /**


### PR DESCRIPTION
I can't send any trx with a quantity less than 0.0001. 
For example：
$tron->send('Txxxxxxx', 0.00001);
This cannot be sent

![git1](https://github.com/iexbase/tron-api/assets/18344060/e48531ac-98d9-4df8-ae1a-b67a5e078c93)

![git2](https://github.com/iexbase/tron-api/assets/18344060/a51f9567-442a-4d73-a836-7e6ba206f8aa)


Modifying the code here can solve this problem

I can send 0.000001 trx 

![git4](https://github.com/iexbase/tron-api/assets/18344060/b69122f8-43fd-45a7-af6c-bc2a8b679f40)


![git3](https://github.com/iexbase/tron-api/assets/18344060/faebf0ff-2d75-43ec-b8ba-aebc5fa8414d)
